### PR TITLE
Add profiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ curl:
 .PHONY: docker-run
 ## docker-run: Run the container
 docker-run: docker-build
-	@docker run --rm -e PORT=8080 -p 8080:8080 jumble-proxy-server:latest
+	@docker run --rm -e ENABLE_PPROF=true -e PORT=8080 -p 8080:8080 jumble-proxy-server:latest
 
 .PHONY: test
 ## test: Runs the tests

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -141,8 +141,10 @@ func proxyHandler(logger *slog.Logger) func(w http.ResponseWriter, r *http.Reque
 
 		// Set the status code and write the response body.
 		w.WriteHeader(resp.StatusCode)
-		body, _ := io.ReadAll(resp.Body)
-		w.Write(body)
+		_, err = io.Copy(w, resp.Body)
+		if err != nil {
+			logger.Error(fmt.Sprintf("Error copying response body: %v", err))
+		}
 	}
 }
 

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"net/http"
+	"net/http/pprof"
+	"os"
 
 	"github.com/danvergara/jumble-proxy-server/pkg/config"
 )
@@ -10,4 +12,20 @@ import (
 func addRoutes(mux *http.ServeMux, cfg *config.Config) {
 	proxy := http.HandlerFunc(proxyHandler(cfg.Logger))
 	mux.Handle("GET /sites/{site}", loggingMiddlware(proxy, cfg.Logger))
+
+	// Add pprof routes only if enabled
+	if os.Getenv("ENABLE_PPROF") == "true" {
+		mux.HandleFunc("/debug/pprof/", pprof.Index)
+		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+		mux.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
+		mux.Handle("/debug/pprof/heap", pprof.Handler("heap"))
+		mux.Handle("/debug/pprof/allocs", pprof.Handler("allocs"))
+		mux.Handle("/debug/pprof/block", pprof.Handler("block"))
+		mux.Handle("/debug/pprof/mutex", pprof.Handler("mutex"))
+
+		cfg.Logger.Info("pprof endpoints enabled at /debug/pprof/")
+	}
 }


### PR DESCRIPTION
This PR fixes #3.

# Memory Leak Fix Summary - Jumble Proxy Server

## Problem Identification

### Initial Memory Profile (Before Fix)
```
flat  flat%   sum%        cum   cum%
5922.86kB 20.77% 20.77%  5922.86kB 20.77%  io.ReadAll
3078kB 10.79% 31.56%     3078kB 10.79%  runtime.allocm
2707.76kB  9.50% 41.06%  5613.73kB 19.69%  compress/flate.NewWriter
```

**Key Finding**: `io.ReadAll` was the top memory consumer at 20.77% (5.9MB), confirming the memory leak hypothesis.

### Root Cause
In `pkg/server/handlers.go:144`, the proxy was reading entire response bodies into memory:
```go
body, _ := io.ReadAll(resp.Body)
w.Write(body)
```

This caused memory accumulation as response bodies were held in memory instead of being streamed.

## Solution Applied

### Code Change
Replaced the memory-accumulating approach with streaming:
```go
// Before (memory leak):
body, _ := io.ReadAll(resp.Body)
w.Write(body)

// After (fixed):
_, err = io.Copy(w, resp.Body)
if err != nil {
    logger.Error(fmt.Sprintf("Error copying response body: %v", err))
}
```

## Results

### Memory Profile After Fix #1
```
flat  flat%   sum%        cum   cum%
1026kB 28.56% 28.56%     1026kB 28.56%  runtime.allocm
518.02kB 14.42% 42.97%   518.02kB 14.42%  crypto/internal/fips140/nistec.(*P384Point).generatorTable.func1
512.69kB 14.27% 57.24%   512.69kB 14.27%  encoding/pem.Decode
```

**Result**: 
- `io.ReadAll` completely eliminated from top memory consumers
- Total memory usage dropped from ~28.5MB to ~3.5MB (87% reduction)
- Only standard runtime and crypto allocations remain

### Memory Profile After Fix #2 (With Load)
```
flat  flat%   sum%        cum   cum%
1805.17kB 17.90% 17.90%  2388.18kB 23.68%  compress/flate.NewWriter
1539kB 15.26% 33.16%  2051.56kB 20.34%  runtime.allocm
583.01kB  5.78% 38.94%   583.01kB  5.78%  compress/flate.newDeflateFast (inline)
```

**Result**:
- `io.ReadAll` still absent - fix confirmed stable
- Remaining allocations are from compression (normal for compressed responses)
- No memory accumulation from response bodies

## Summary

✅ **Memory leak fixed** by replacing `io.ReadAll` with `io.Copy`
✅ **87% memory reduction** achieved
✅ **Streaming approach** prevents response body accumulation
✅ **Fix verified stable** under load

The proxy now streams responses directly to clients without holding them in memory, completely eliminating the memory leak.

Also, this PR adds some profiling using `pprof`, but it's enabled by the presence of the environment variable `ENABLE_PPROF`. Production shouldn't be affected by this.