### PR TITLE
Add support for github releases

### DIFF
--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -80,13 +80,14 @@ func TestGithubClient_GetURLResourceType(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "unknown resource type - releases",
+			name: "release tag",
 			url:  "https://github.com/owner/repo/releases/tag/v1.0.0",
 			expected: URLResourceInfo{
-				Type:   Unknown,
-				Owner:  "",
-				Repo:   "",
-				Number: 0,
+				Type:    Release,
+				Owner:   "owner",
+				Repo:    "repo",
+				Number:  0,
+				Version: "v1.0.0",
 			},
 			expectError: false,
 		},
@@ -156,6 +157,54 @@ func TestGithubClient_GetURLResourceType(t *testing.T) {
 			},
 			expectError: true,
 		},
+		{
+			name: "release with semantic version",
+			url:  "https://github.com/golang/go/releases/tag/go1.21.0",
+			expected: URLResourceInfo{
+				Type:    Release,
+				Owner:   "golang",
+				Repo:    "go",
+				Number:  0,
+				Version: "go1.21.0",
+			},
+			expectError: false,
+		},
+		{
+			name: "release without v prefix",
+			url:  "https://github.com/owner/repo/releases/tag/1.0.0",
+			expected: URLResourceInfo{
+				Type:    Release,
+				Owner:   "owner",
+				Repo:    "repo",
+				Number:  0,
+				Version: "1.0.0",
+			},
+			expectError: false,
+		},
+		{
+			name: "release with complex tag",
+			url:  "https://github.com/owner/repo/releases/tag/release-2023.10.15",
+			expected: URLResourceInfo{
+				Type:    Release,
+				Owner:   "owner",
+				Repo:    "repo",
+				Number:  0,
+				Version: "release-2023.10.15",
+			},
+			expectError: false,
+		},
+		{
+			name: "release with trailing slash",
+			url:  "https://github.com/owner/repo/releases/tag/v2.0.0/",
+			expected: URLResourceInfo{
+				Type:    Release,
+				Owner:   "owner",
+				Repo:    "repo",
+				Number:  0,
+				Version: "v2.0.0",
+			},
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -201,6 +250,14 @@ func TestGithubClient_GetURLResourceType(t *testing.T) {
 					tt.expected.Number,
 				)
 			}
+
+			if result.Version != tt.expected.Version {
+				t.Errorf(
+					"GetURLResourceType() Version = %v, expected %v",
+					result.Version,
+					tt.expected.Version,
+				)
+			}
 		})
 	}
 }
@@ -214,6 +271,7 @@ func TestResourceType_String(t *testing.T) {
 		{Repository, "repository"},
 		{Issue, "issue"},
 		{PullRequest, "pull_request"},
+		{Release, "release"},
 		{Unknown, "unknown"},
 	}
 


### PR DESCRIPTION
# Add GitHub Releases Support

## Overview
This PR adds support for GitHub release URLs in the jumble-proxy-server, enabling proper OpenGraph metadata generation for GitHub release pages.

## Changes Made

### 1. Added Release Resource Type
- Added `Release` to the `ResourceType` enum in `pkg/github/github.go`
- Implemented `String()` method support for the Release type

### 2. Enhanced URL Parsing
- Updated `URLResourceInfo` struct to include a `Version` field for storing release tags
- Modified `getResourceFromURL()` to parse GitHub release URLs in the format:
  - `https://github.com/owner/repo/releases/tag/{tag_name}`
- Handles various tag formats: `v1.0.0`, `1.0.0`, `go1.21.0`, `release-2023.10.15`

### 3. Implemented Release Query Support
- Added Release case to `queryGitHubResource()` method
- Uses GitHub API's `GetReleaseByTag()` to fetch release information
- Generates proper OpenGraph image URLs using the githubassets API:
  - Format: `https://opengraph.githubassets.com/{hash}/{owner}/{repo}/releases/tag/{tag_name}`

### 4. Comprehensive Test Coverage
- Updated existing test that incorrectly expected release URLs to return `Unknown` type
- Added multiple test cases for release URL parsing:
  - Releases with semantic versioning
  - Releases without 'v' prefix
  - Releases with complex tag names
  - Releases with trailing slashes
- Added Version field validation in tests
- Added Release type to `ResourceType.String()` tests

## Technical Details

### API Integration
The implementation leverages the existing GitHub API client (`go-github/v74`) to fetch release data:
```go
release, _, err := gc.client.Repositories.GetReleaseByTag(ctx, owner, repo, tag)
```

### OpenGraph Image Generation
Release OpenGraph images follow the same pattern as other GitHub resources, using the githubassets API with the specific path format for releases.

## Testing
All tests pass successfully:
- URL parsing correctly identifies release URLs and extracts version information
- Release data is properly fetched from the GitHub API
- OpenGraph metadata is correctly generated

## Impact
This enhancement allows the proxy server to properly handle GitHub release URLs, providing rich preview cards when sharing release links in applications that support OpenGraph metadata.
